### PR TITLE
Firefox Support

### DIFF
--- a/dist/D3SeatingChart.js
+++ b/dist/D3SeatingChart.js
@@ -9,7 +9,7 @@ const D3SeatingChartDefaultConfig = {
     allowManualSelection: true
 };
 class D3SeatingChart {
-    constructor(element, margin = 0) {
+    constructor(element, margin = 20) {
         this.element = element;
         this.margin = margin;
         this.history = [];
@@ -428,7 +428,7 @@ class D3SeatingChart {
         }
         return ele;
     }
-    static attach(element, config = D3SeatingChartDefaultConfig, margin = 0) {
+    static attach(element, config = D3SeatingChartDefaultConfig, margin = 20) {
         let d3s = new D3SeatingChart(element, margin);
         d3s.init(config);
         return d3s;

--- a/dist/D3SeatingChart.js
+++ b/dist/D3SeatingChart.js
@@ -9,9 +9,9 @@ const D3SeatingChartDefaultConfig = {
     allowManualSelection: true
 };
 class D3SeatingChart {
-    constructor(element) {
+    constructor(element, margin = 0) {
         this.element = element;
-        this.margin = 20;
+        this.margin = margin;
         this.history = [];
         this.zoomChangedListeners = [];
         this.selectionChangeListeners = [];
@@ -99,16 +99,17 @@ class D3SeatingChart {
         this.focusedElement = selection;
         let all = boardSelection.selectAll(`*`);
         let activeLayer = selection.selectAll('.focused > *');
-        let parentWidth = this.element.clientWidth;
-        let parentHeight = this.element.clientHeight;
+        let parentWidth = this.element.clientWidth || this.element.getBoundingClientRect().width;
+        let parentHeight = this.element.clientHeight || this.element.getBoundingClientRect().height;
+        if (!parentWidth || !parentHeight) return;
         let desiredWidth = parentWidth - this.margin * 2;
         let desiredHeight = parentHeight - this.margin * 2;
         let widthRatio = desiredWidth / boundingBox.width;
         let heightRatio = desiredHeight / boundingBox.height;
         let ratio = Math.min(widthRatio, heightRatio);
         scaleTransform = `scale(${ratio})`;
-        let newX = (this.element.clientWidth / 2 - boundingBox.width * ratio / 2 - boundingBox.x * ratio);
-        let newY = (this.element.clientHeight / 2 - boundingBox.height * ratio / 2 - boundingBox.y * ratio);
+        let newX = (parentWidth / 2 - boundingBox.width * ratio / 2 - boundingBox.x * ratio);
+        let newY = (parentHeight / 2 - boundingBox.height * ratio / 2 - boundingBox.y * ratio);
         translateTransform = `translate(${newX},${newY})`;
         let currentTransform = selection.attr('transform');
         if (!currentTransform) {
@@ -427,8 +428,8 @@ class D3SeatingChart {
         }
         return ele;
     }
-    static attach(element, config = D3SeatingChartDefaultConfig) {
-        let d3s = new D3SeatingChart(element);
+    static attach(element, config = D3SeatingChartDefaultConfig, margin = 0) {
+        let d3s = new D3SeatingChart(element, margin);
         d3s.init(config);
         return d3s;
     }

--- a/dist/D3SeatingChart.js
+++ b/dist/D3SeatingChart.js
@@ -101,7 +101,9 @@ class D3SeatingChart {
         let activeLayer = selection.selectAll('.focused > *');
         let parentWidth = this.element.clientWidth || this.element.getBoundingClientRect().width;
         let parentHeight = this.element.clientHeight || this.element.getBoundingClientRect().height;
-        if (!parentWidth || !parentHeight) return;
+        if (!parentWidth || !parentHeight) {
+            throw new Error('SVG dimensions must be postive values ' + this.element.outerHTML);
+        }
         let desiredWidth = parentWidth - this.margin * 2;
         let desiredHeight = parentHeight - this.margin * 2;
         let widthRatio = desiredWidth / boundingBox.width;

--- a/dist/D3SeatingChart.js
+++ b/dist/D3SeatingChart.js
@@ -102,7 +102,7 @@ class D3SeatingChart {
         let parentWidth = this.element.clientWidth || this.element.getBoundingClientRect().width;
         let parentHeight = this.element.clientHeight || this.element.getBoundingClientRect().height;
         if (!parentWidth || !parentHeight) {
-            throw new Error('SVG dimensions must be postive values ' + this.element.outerHTML);
+            throw new Error(`SVG dimensions must be positive values. Received width: ${parentWidth} and height: ${parentHeight}`);
         }
         let desiredWidth = parentWidth - this.margin * 2;
         let desiredHeight = parentHeight - this.margin * 2;

--- a/dist/D3SeatingChart.js
+++ b/dist/D3SeatingChart.js
@@ -166,7 +166,7 @@ class D3SeatingChart {
     bindEvents() {
         let self = this;
         this.selectElements('[zoom-control]').on('click', (d) => {
-            let ele = d3.event.srcElement;
+            let ele = d3.event.srcElement || d3.event.target;
             let expose = ele.getAttribute('zoom-control');
             if (expose) {
                 this.zoom(this.selectElement(`[zoom-target="${expose}"]`));

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-exports.D3SeatingChart = require('./dist/d3SeatingChart.js').D3SeatingChart;
+exports.D3SeatingChart = require('./dist/D3SeatingChart.js').D3SeatingChart;
 exports.SelectionChangeEvent = require('./dist/selectionChangeEvent.model.js').SelectionChangeEvent;
 exports.SelectionChangeEventReason = require('./dist/selectionChangeEvent.model.js').SelectionChangeEventReason;
 exports.ShowBehavior = require('./dist/showBehavior.enum.js').ShowBehavior;

--- a/src/D3SeatingChart.ts
+++ b/src/D3SeatingChart.ts
@@ -29,7 +29,7 @@ export class D3SeatingChart {
   private config: D3SeatingChartConfig;
 
   private uniqueIdentifier: string;
-  
+
   private constructor(private element: HTMLElement, private margin: number = 20) {}
 
   private init(config: D3SeatingChartConfig) {
@@ -52,7 +52,7 @@ export class D3SeatingChart {
 
   public stripStyles(selector: string) {
     let svgSelection = d3.select(this.element);
-    
+
     svgSelection.selectAll(selector)
       .attr('stroke', null)
       .attr('stroke-width', null)
@@ -144,10 +144,12 @@ export class D3SeatingChart {
     let activeLayer = selection.selectAll('.focused > *');
 
     // resize
-    
+
     let parentWidth = this.element.clientWidth || this.element.getBoundingClientRect().width;
     let parentHeight = this.element.clientHeight || this.element.getBoundingClientRect().height;
-    if (!parentWidth || !parentHeight) return;
+    if (!parentWidth || !parentHeight) {
+      throw new Error(`SVG dimensions must be positive values. Received width: ${parentWidth} and height: ${parentHeight}`);
+    }
 
     let desiredWidth = parentWidth - this.margin*2;
     let desiredHeight = parentHeight - this.margin*2;
@@ -156,11 +158,11 @@ export class D3SeatingChart {
     let heightRatio = desiredHeight / boundingBox.height;
 
     let ratio = Math.min(widthRatio, heightRatio);
-    
+
     scaleTransform = `scale(${ratio})`;
-    
+
     // center
-    
+
     let newX = (parentWidth / 2 - boundingBox.width * ratio / 2 - boundingBox.x * ratio);
     let newY = (parentHeight / 2 - boundingBox.height * ratio / 2 - boundingBox.y * ratio);
 
@@ -187,7 +189,7 @@ export class D3SeatingChart {
         .duration(animate ? 300 : 0)
         .style('opacity', 1);
     }
-      
+
     //activeLayer.style('pointer-events', 'inherit');
 
     boardSelection.transition()
@@ -233,7 +235,7 @@ export class D3SeatingChart {
     let self = this;
 
     this.selectElements('[zoom-control]').on('click', (d) => {
-      let ele = d3.event.srcElement;
+      let ele = d3.event.srcElement || d3.event.target;
       let expose = ele.getAttribute('zoom-control');
 
       if(expose) {
@@ -376,7 +378,7 @@ export class D3SeatingChart {
     let sortedSeats = seats.sort((a, b) => {
       let aX = Math.round(parseFloat(a.getAttribute('x')));
       let aY = Math.round(parseFloat(a.getAttribute('y')));
-      
+
       let bX = Math.round(parseFloat(b.getAttribute('x')));
       let bY = Math.round(parseFloat(b.getAttribute('y')));
 
@@ -481,7 +483,7 @@ export class D3SeatingChart {
 
           lastSeat = seat;
         }
-        
+
         if(br == -1) {
           sections.push(sortedSeatsCopy.splice(0, sortedSeatsCopy.length));
         } else {
@@ -497,7 +499,7 @@ export class D3SeatingChart {
         }
       }
     }
-    
+
     if(!contiguous || scatterFallback) {
       return sortedSeats.filter(x => !x.hasAttribute('locked')).splice(0, numSeats);
     }

--- a/src/D3SeatingChart.ts
+++ b/src/D3SeatingChart.ts
@@ -30,7 +30,7 @@ export class D3SeatingChart {
 
   private uniqueIdentifier: string;
   
-  private constructor(private element: HTMLElement, , private margin: number = 20) {}
+  private constructor(private element: HTMLElement, private margin: number = 20) {}
 
   private init(config: D3SeatingChartConfig) {
     let svgSelection = d3.select(this.element);

--- a/src/D3SeatingChart.ts
+++ b/src/D3SeatingChart.ts
@@ -16,8 +16,6 @@ export type ElementSelector = SVGElement | SVGElement[] | string;
 
 export class D3SeatingChart {
 
-  private margin: number = 20;
-
   public focusedElement: any;
 
   private history: any[] = [];
@@ -32,7 +30,7 @@ export class D3SeatingChart {
 
   private uniqueIdentifier: string;
   
-  private constructor(private element: HTMLElement) {}
+  private constructor(private element: HTMLElement, , private margin: number = 20) {}
 
   private init(config: D3SeatingChartConfig) {
     let svgSelection = d3.select(this.element);
@@ -147,8 +145,9 @@ export class D3SeatingChart {
 
     // resize
     
-    let parentWidth = this.element.clientWidth;
-    let parentHeight = this.element.clientHeight;
+    let parentWidth = this.element.clientWidth || this.element.getBoundingClientRect().width;
+    let parentHeight = this.element.clientHeight || this.element.getBoundingClientRect().height;
+    if (!parentWidth || !parentHeight) return;
 
     let desiredWidth = parentWidth - this.margin*2;
     let desiredHeight = parentHeight - this.margin*2;
@@ -162,8 +161,8 @@ export class D3SeatingChart {
     
     // center
     
-    let newX = (this.element.clientWidth/2 - boundingBox.width*ratio/2 - boundingBox.x*ratio);
-    let newY = (this.element.clientHeight/2 - boundingBox.height*ratio/2 - boundingBox.y*ratio);
+    let newX = (parentWidth / 2 - boundingBox.width * ratio / 2 - boundingBox.x * ratio);
+    let newY = (parentHeight / 2 - boundingBox.height * ratio / 2 - boundingBox.y * ratio);
 
     translateTransform = `translate(${newX},${newY})`;
 
@@ -527,8 +526,8 @@ export class D3SeatingChart {
     return ele;
   }
 
-  static attach(element: HTMLElement, config: D3SeatingChartConfig = D3SeatingChartDefaultConfig) {
-    let d3s = new D3SeatingChart(element);
+  static attach(element: HTMLElement, config: D3SeatingChartConfig = D3SeatingChartDefaultConfig, margin: number = 20) {
+    let d3s = new D3SeatingChart(element, margin);
     d3s.init(config);
     return d3s;
   }

--- a/test/d3sc.bundle.js
+++ b/test/d3sc.bundle.js
@@ -168,7 +168,7 @@ class D3SeatingChart {
     bindEvents() {
         let self = this;
         this.selectElements('[zoom-control]').on('click', (d) => {
-            let ele = d3.event.srcElement;
+            let ele = d3.event.srcElement || d3.event.target;
             let expose = ele.getAttribute('zoom-control');
             if (expose) {
                 this.zoom(this.selectElement(`[zoom-target="${expose}"]`));

--- a/test/test.bundle.js
+++ b/test/test.bundle.js
@@ -168,7 +168,7 @@ class D3SeatingChart {
     bindEvents() {
         let self = this;
         this.selectElements('[zoom-control]').on('click', (d) => {
-            let ele = d3.event.srcElement;
+            let ele = d3.event.srcElement || d3.event.target;
             let expose = ele.getAttribute('zoom-control');
             if (expose) {
                 this.zoom(this.selectElement(`[zoom-target="${expose}"]`));


### PR DESCRIPTION
As described here: https://bugzilla.mozilla.org/show_bug.cgi?id=874811, Firefox will always return `0` for `clientWidth` and `clientHeight`.  This PR will fall back on `this.element.getBoundingClientRect()` should `clientWidth` or `clientHeight` return falsey values.

This PR also:
- Adds the ability to customize the svg margin.
  - Usage: `D3SeatingChart.attach(<element>, <chart_options>, <margin_px>)`
  - e.g.`D3SeatingChart.attach(document.getElementById('my-svg'), { showBehavior: ShowBehavior.AllDecendants }, 5)`
- Will return early from the `zoom` function if `parentWidth` or `parentHeight` are falsey values.  This prevents scaling by 0, transforming by NaN, etc.

Fixes #3 
Fixes #4 
Fixes #5 